### PR TITLE
lastUpdate must be updated before calling a new updateFrame

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -728,6 +728,9 @@ class MovieClip extends flash.display.MovieClip {
 		var frame, displayObject, depth;
 
 		frame = __symbol.frames[index];
+		
+		__currentFrame = index + 1;
+		__lastUpdate = index + 1;
 
 		for (frameObject in frame.objects) {
 
@@ -843,9 +846,6 @@ class MovieClip extends flash.display.MovieClip {
 
 			mask.__clipDepth = result - maskIndex - 1;
 		}
-
-		__currentFrame = index + 1;
-		__lastUpdate = index + 1;
 
 		#if (!flash && openfl && !openfl_legacy)
 		if (__frameScripts != null) {


### PR DESCRIPTION
Previously if an updateFrame() was called before the __lastUpdate was updated, it caused an infinite recursion. It happened because a gotoAndStop() function was called on the event ADDED_TO_STAGE from a child of this movieClip and since the __lastUpdate was updated after, the same frame was infinitely updated.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/swf/15)

<!-- Reviewable:end -->
