### PR TITLE
matrix of sprite depends of itself and not on its depth

### DIFF
--- a/format/swf/timeline/Frame.hx
+++ b/format/swf/timeline/Frame.hx
@@ -72,6 +72,7 @@ class Frame
 					// An entirely new character is placed at this depth.
 					frameObject.characterId = tag.characterId;
 					frameObject.lastModifiedAtIndex = tagIndex;
+					frameObject.placedAtIndex = tagIndex;
 				}
 			}
 		} else {


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/swf/17)

<!-- Reviewable:end -->
