### PR TITLE
Fix gotoAndPlay()

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -161,6 +161,7 @@ class MovieClip extends flash.display.MovieClip {
 	public override function gotoAndPlay (frame:#if flash flash.utils.Object #else Dynamic #end, scene:String = null):Void {
 
 		__goto(frame, scene);
+		play();
 	}
 
 
@@ -544,10 +545,12 @@ class MovieClip extends flash.display.MovieClip {
 
 		if(__targetFrame == null) {
 
-			__targetFrame = __getFrame (frame);
-			if ( __targetFrame == __currentFrame ) {
+			var targetFrame = __getFrame (frame);
+			if ( targetFrame == __currentFrame ) {
 				return true;
 			}
+
+			__targetFrame = targetFrame;
 			play ();
 
 			do {


### PR DESCRIPTION
This fixes a regression. When `gotoAndPlay` was called with current frame as argument, the movie clip would not play. 

Also, it would left `_targetFrame` to an invalid value, discarding any subsequent calls

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/swf/38)

<!-- Reviewable:end -->
