### PR TITLE
Fix premultiplication of merged texture

### DIFF
--- a/format/swf/exporters/SWFLiteExporter.hx
+++ b/format/swf/exporters/SWFLiteExporter.hx
@@ -351,7 +351,7 @@ class SWFLiteExporter {
 					alphaByteArray = null;
 					byteArray = lime.graphics.format.PNG.encode( image );
 
-					type = BitmapType.PNG;
+					type = BitmapType.PNG_ALPHA;
 
 				} else {
 
@@ -909,6 +909,7 @@ class SWFLiteExporter {
 enum BitmapType {
 	
 	PNG;
+	PNG_ALPHA;
 	JPEG_ALPHA;
 	JPEG;
 	

--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -467,6 +467,14 @@ class MovieClip extends flash.display.MovieClip {
 
 			}
 
+			if( symbol.unpremultiply ){
+				source.buffer.premultiplied = true;
+
+				#if !sys
+				source.premultiplied = false;
+				#end
+			}
+
 			#if !flash
 			var bitmapData = BitmapData.fromImage (source);
 			#else

--- a/format/swf/lite/symbols/BitmapSymbol.hx
+++ b/format/swf/lite/symbols/BitmapSymbol.hx
@@ -6,8 +6,9 @@ class BitmapSymbol extends SWFSymbol {
 	
 	public var alpha:String;
 	public var path:String;
-	
-	
+	public var unpremultiply:Bool;
+
+
 	public function new () {
 		
 		super ();

--- a/tools/Tools.hx
+++ b/tools/Tools.hx
@@ -658,10 +658,12 @@ class Tools {
 					var swfLite = exporter.swfLite;
 					
 					for (id in exporter.bitmaps.keys ()) {
-						
-						var type = exporter.bitmapTypes.get (id) == BitmapType.PNG ? "png" : "jpg";
+
+						var sourceType = exporter.bitmapTypes.get (id);
+						var type = ( sourceType == BitmapType.PNG || sourceType == BitmapType.PNG_ALPHA )  ? "png" : "jpg";
 						var symbol:BitmapSymbol = cast swfLite.symbols.get (id);
 						symbol.path = "lib/" + library.name + "/" + id + "." + type;
+						symbol.unpremultiply = sourceType == BitmapType.PNG_ALPHA;
 						swfLite.symbols.set (id, symbol);
 						
 						var asset = new Asset ("", symbol.path, AssetType.IMAGE);


### PR DESCRIPTION
Merge png needs to be treated differently from swf encoded png.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/swf/41)

<!-- Reviewable:end -->
