### PR TITLE
Framescripts can change the flow and override a users commmand.

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -581,8 +581,6 @@ class MovieClip extends flash.display.MovieClip {
 		}
 		else {
 
-			__targetFrame = __getFrame (frame);
-
 			return false;
 		}
 


### PR DESCRIPTION
This is not desired. e.g.:  gotoAndStart / gotoAndStop by user can be overwritten by gotoAndStart / gotoAndStop commands in framescripts.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/swf/57)

<!-- Reviewable:end -->
